### PR TITLE
add support sendCommand

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,5 @@
 {
+  "maxcomplexity": 2,
   "globalstrict": true,
   "browser": true,
   "browserify": true,

--- a/lib/command.js
+++ b/lib/command.js
@@ -1,20 +1,27 @@
 'use strict';
 
-var Command = function (params) {
-    this.msg = params.msg;
-    this.promise = new Promise(function (resolve) {
+var Command = function (msg) {
+    this.msg = msg;
+    this.promise = new Promise(function (resolve, reject) {
         this.resolve = resolve;
+        this.reject = reject;
     }.bind(this));
 };
 
-Command.prototype.done = function (msg) {
-    this.resolve(msg);
+Command.prototype.done = function (respond) {
+    this.resolve(respond);
+    this.destroy();
+};
+
+Command.prototype.fail = function () {
+    this.reject();
     this.destroy();
 };
 
 Command.prototype.destroy = function () {
     delete this.msg;
     delete this.resolve;
+    delete this.reject;
 };
 
 module.exports = Command;

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -1,0 +1,50 @@
+'use strict';
+
+var Command = require('./command');
+
+var Commands = function (params) {
+    this.state = params.state;
+    this.send = params.send;
+    this.openCommands = [];
+};
+
+Commands.prototype.create = function (msg) {
+    var command = new Command(msg);
+
+    this.openCommands.push(command);
+
+    if (this.state.isConnected()) {
+        this.send(msg);
+    } else {
+        command.fail();
+    }
+    return command.promise;
+};
+
+Commands.prototype.findAndResolve = function (msg, clientMsgId) {
+    var command = this.find(clientMsgId);
+    if (command) {
+        this.delete(command);
+        command.done(msg);
+        return true;
+    }
+};
+
+Commands.prototype.fail = function () {
+    this.openCommands.forEach(function (command) {
+        command.fail();
+    });
+};
+
+Commands.prototype.find = function (clientMsgId) {
+    return this.openCommands.find(function (command) {
+        return command.msg.clientMsgId === clientMsgId;
+    });
+};
+
+Commands.prototype.delete = function (command) {
+    var index = this.openCommands.indexOf(command);
+    this.openCommands.splice(index, 1);
+};
+
+module.exports = Commands;

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -1,9 +1,10 @@
 'use strict';
 
 var EventEmitter = require('events');
-var state = require('./state');
-var Command = require('./command');
+var State = require('./state');
 var util = require('util');
+var GuaranteedCommands = require('./guaranteed_commands');
+var Commands = require('./commands');
 
 var Connect = function (params) {
     EventEmitter.call(this);
@@ -21,8 +22,15 @@ Connect.prototype.init = function () {
     this.socket = undefined;
     this.startTime = undefined;
     this.pingInterval = undefined;
-    this.state = state.disconnect;
-    this.openCommands = [];
+    this.state = new State();
+    this.guaranteedCommands = new GuaranteedCommands({
+        state: this.state,
+        send: this.send.bind(this)
+    });
+    this.commands = new Commands({
+        state: this.state,
+        send: this.send.bind(this)
+    });
 
     this.encodeDecode.registerDecodeHandler(
         this.onMessage.bind(this)
@@ -34,8 +42,7 @@ Connect.prototype.start = function () {
 
     adapter.onOpen = this.onOpen.bind(this);
     adapter.onData = this.onData.bind(this);
-    adapter.onEnd = this._onEnd.bind(this);
-    adapter.onError = this._onError.bind(this);
+    adapter.onError = adapter.onEnd = this._onEnd.bind(this);
 
     adapter.connect();
 };
@@ -46,34 +53,25 @@ Connect.prototype.onData = function (data) {
 
 Connect.prototype.onOpen = function () {
     this.startTime = new Date();
-    this.state = state.connected;
+    this.state.connected();
 
-    this.resendCommands();
+    this.guaranteedCommands.resend();
     this.onConnect();
 };
 
-Connect.prototype.onConnect = function () {};
-
-Connect.prototype.resendCommands = function () {
-    this.openCommands.forEach(function (command) {
-        this.sendCommand(command.msg);
-    }, this);
-};
-
 Connect.prototype.sendGuaranteedCommand = function (payloadType, params) {
-    var msg = this.protocol.encode(payloadType, params);
-
-    var command = new Command({msg: msg});
-
-    this.openCommands.push(command);
-
-    if (this.isConnected()) {
-        this.sendCommand(msg);
-    }
-    return command.promise;
+    return this.guaranteedCommands.create(
+        this.protocol.encode(payloadType, params)
+    );
 };
 
-Connect.prototype.sendCommand = function (msg) {
+Connect.prototype.sendCommand = function (payloadType, params) {
+    return this.commands.create(
+        this.protocol.encode(payloadType, params)
+    );
+};
+
+Connect.prototype.send = function (msg) {
     var data = this.encodeDecode.encode(msg);
     this.adapter.send(data);
 };
@@ -92,38 +90,21 @@ Connect.prototype.onMessage = function (data) {
 };
 
 Connect.prototype.processMessage = function (msg, clientMsgId) {
-    var command = this.findCommand(clientMsgId);
-    command.done(msg);
-    this.deleteCommand(command);
+    return this.guaranteedCommands.findAndResolve(msg, clientMsgId) || this.commands.findAndResolve(msg, clientMsgId);
 };
 
 Connect.prototype.processPushEvent = function (msg, payloadType) {
     this.emit(payloadType, msg);
 };
 
-Connect.prototype.findCommand = function (clientMsgId) {
-    return this.openCommands.find(function (command) {
-        return command.msg.clientMsgId === clientMsgId;
-    });
+Connect.prototype._onEnd = function (e) {
+    this.state.disconnected();
+    this.commands.fail();
+    this.onEnd(e);
 };
 
-Connect.prototype.deleteCommand = function (command) {
-    var index = this.openCommands.indexOf(command);
-    this.openCommands.splice(index, 1);
-};
+Connect.prototype.onConnect = function () {};
 
-Connect.prototype._onEnd = function () {
-    this.state = state.disconnected;
-    this.onEnd();
-};
-
-Connect.prototype._onError = function (e) {
-    this.state = state.disconnected;
-    this.onError(e);
-};
-
-Connect.prototype.isConnected = function () {
-    return this.state === state.connected;
-};
+Connect.prototype.onEnd = function () {};
 
 module.exports = Connect;

--- a/lib/guaranteed_command.js
+++ b/lib/guaranteed_command.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var GuaranteedCommand = function (msg) {
+    this.msg = msg;
+    this.promise = new Promise(function (resolve) {
+        this.resolve = resolve;
+    }.bind(this));
+};
+
+GuaranteedCommand.prototype.done = function (msg) {
+    this.resolve(msg);
+    this.destroy();
+};
+
+GuaranteedCommand.prototype.destroy = function () {
+    delete this.msg;
+    delete this.resolve;
+};
+
+module.exports = GuaranteedCommand;

--- a/lib/guaranteed_commands.js
+++ b/lib/guaranteed_commands.js
@@ -1,0 +1,50 @@
+'use strict';
+
+var GuaranteedCommand = require('./guaranteed_command');
+
+var GuaranteedCommands = function (params) {
+    this.state = params.state;
+    this.send = params.send;
+    this.openCommands = [];
+};
+
+GuaranteedCommands.prototype.create = function (msg) {
+    var command = new GuaranteedCommand(msg);
+
+    this.openCommands.push(command);
+
+    if (this.state.isConnected()) {
+        this.send(msg);
+    }
+    return command.promise;
+};
+
+GuaranteedCommands.prototype.resend = function () {
+    this.openCommands
+        .map(function (command) {
+            return command.msg;
+        })
+        .forEach(this.send);
+};
+
+GuaranteedCommands.prototype.findAndResolve = function (msg, clientMsgId) {
+    var command = this.find(clientMsgId);
+    if (command) {
+        this.delete(command);
+        command.done(msg);
+        return true;
+    }
+};
+
+GuaranteedCommands.prototype.find = function (clientMsgId) {
+    return this.openCommands.find(function (command) {
+        return command.msg.clientMsgId === clientMsgId;
+    });
+};
+
+GuaranteedCommands.prototype.delete = function (command) {
+    var index = this.openCommands.indexOf(command);
+    this.openCommands.splice(index, 1);
+};
+
+module.exports = GuaranteedCommands;

--- a/lib/state.js
+++ b/lib/state.js
@@ -1,8 +1,19 @@
 'use strict';
 
-var state = {
-    disconnected: false,
-    connected: true
+var State = function () {
+    this.disconnected();
 };
 
-module.exports = state;
+State.prototype.disconnected = function () {
+    this.value = false;
+};
+
+State.prototype.connected = function () {
+    this.value = true;
+};
+
+State.prototype.isConnected = function () {
+    return this.value;
+};
+
+module.exports = State;

--- a/test/sendCommand.js
+++ b/test/sendCommand.js
@@ -1,0 +1,87 @@
+'use strict';
+
+var ProtoMessages = require('connect-protobuf-messages');
+var AdapterTLS = require('connect-js-adapter-tls');
+var EncodeDecode = require('connect-js-encode-decode');
+var Connect = require('../lib/connect');
+
+describe('sendCommand', function () {
+    var connect;
+    var adapter;
+    var protoMessages;
+    var encodeDecode;
+    var payloadType;
+    var sendCommand;
+
+    var makeAdapterLazy = function (respondDelay) {
+        var send = adapter.send.bind(adapter);
+        adapter.send = function (data) {
+            setTimeout(function () {
+                send(data);
+            }, respondDelay);
+        };
+    };
+
+    beforeAll(function () {
+        protoMessages = new ProtoMessages([
+            {
+                file: 'node_modules/connect-protobuf-messages/src/main/protobuf/CommonMessages.proto',
+                protoPayloadType: 'ProtoPayloadType'
+            },
+            {
+                file: 'node_modules/connect-protobuf-messages/src/main/protobuf/OpenApiMessages.proto',
+                protoPayloadType: 'ProtoOAPayloadType'
+            }
+        ]);
+
+        protoMessages.load();
+        protoMessages.build();
+
+        payloadType = protoMessages.getPayloadTypeByName('ProtoPingReq');
+
+        encodeDecode = new EncodeDecode();
+    });
+
+    beforeEach(function (done) {
+        adapter = new AdapterTLS({
+            host: 'sandbox-tradeapi.spotware.com',
+            port: 5032
+        });
+
+        connect = new Connect({
+            adapter: adapter,
+            encodeDecode: encodeDecode,
+            protocol: protoMessages
+        });
+
+        sendCommand = function () {
+            return connect.sendCommand(payloadType, {
+                timestamp: Date.now()
+            });
+        };
+
+        connect.onConnect = done;
+        connect.start();
+    });
+
+    it('resolved by respond', function (done) {
+        sendCommand().then(done);
+    });
+
+    it('refect by closing connection', function (done) {
+        makeAdapterLazy({
+            respondDelay: 1000
+        });
+
+        sendCommand().then(null, done);
+
+        adapter.onEnd();
+    });
+
+    it('execute command with close connection', function (done) {
+        adapter.onEnd();
+
+        sendCommand().then(null, done);
+    });
+
+});


### PR DESCRIPTION
.sendCommand can be send only at open connection and NOT wait for establishment connection.
.sendGuaranteedCommand will wait establishment connection and could be resolve by respond only.

.sendCommand return promise, it can become resolve/rejected
.sendGuaranteedCommand return promise, it can become resolved
